### PR TITLE
File name collision fix and minor extentions

### DIFF
--- a/match_pairs.py
+++ b/match_pairs.py
@@ -63,6 +63,15 @@ from models.utils import (compute_pose_error, compute_epipolar_error,
 torch.set_grad_enabled(False)
 
 
+def pair_names_to_id(names):
+    # Remove extention
+    names = [str(Path(name).with_suffix('')) for name in names]
+    # Replace '/'
+    names = [name.replace('/', '__') for name in names]
+    # Concat
+    return names[0] + '___' + names[1]
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Image pair matching and pose evaluation with SuperGlue',
@@ -217,11 +226,11 @@ if __name__ == '__main__':
     for i, pair in enumerate(pairs):
         name0, name1 = pair[:2]
         stem0, stem1 = Path(name0).stem, Path(name1).stem
-        matches_path = output_dir / '{}_{}_matches.npz'.format(stem0, stem1)
-        eval_path = output_dir / '{}_{}_evaluation.npz'.format(stem0, stem1)
-        viz_path = output_dir / '{}_{}_matches.{}'.format(stem0, stem1, opt.viz_extension)
-        viz_eval_path = output_dir / \
-            '{}_{}_evaluation.{}'.format(stem0, stem1, opt.viz_extension)
+        pair_id = pair_names_to_id((name0, name1))
+        matches_path = output_dir / f'{pair_id}_matches.npz'
+        eval_path = output_dir / f'{pair_id}_evaluation.npz'
+        viz_path = output_dir / f'{pair_id}_matches.{opt.viz_extension}'
+        viz_eval_path = output_dir / f'{pair_id}_evaluation.{opt.viz_extension}'
 
         # Handle --cache logic.
         do_match = True
@@ -280,7 +289,7 @@ if __name__ == '__main__':
         # Load the optional custom points
         if opt.input_points is not None:
             input_points_dir = Path(opt.input_points)
-            with open(input_points_dir / f'{stem0}_{stem1}.pkl', 'rb') as f:
+            with open(input_points_dir / f'{pair_id}.pkl', 'rb') as f:
                 pts0, pts1 = pickle.load(f)
         else:
             pts0, pts1 = None, None
@@ -296,11 +305,13 @@ if __name__ == '__main__':
             pred = {k: v[0].cpu().numpy() for k, v in pred.items()}
             kpts0, kpts1 = pred['keypoints0'], pred['keypoints1']
             matches, conf = pred['matches0'], pred['matching_scores0']
+            matches1, conf1 = pred['matches1'], pred['matching_scores1']
             timer.update('matcher')
 
             # Write the matches to disk.
             out_matches = {'keypoints0': kpts0, 'keypoints1': kpts1,
-                           'matches': matches, 'match_confidence': conf}
+                           'matches0': matches, 'match_confidence0': conf,
+                           'matches1': matches1, 'match_confidence1': conf1}
             np.savez(str(matches_path), **out_matches)
 
         # Keep the matching keypoints.

--- a/models/matching.py
+++ b/models/matching.py
@@ -63,10 +63,16 @@ class Matching(torch.nn.Module):
 
         # Extract SuperPoint (keypoints, scores, descriptors) if not provided
         if 'keypoints0' not in data:
-            pred0 = self.superpoint({'image': data['image0']})
+            superpoint_args0 = {'image': data['image0']}
+            if 'points0' in data:
+                superpoint_args0['points'] = data['points0']
+            pred0 = self.superpoint(superpoint_args0)
             pred = {**pred, **{k+'0': v for k, v in pred0.items()}}
         if 'keypoints1' not in data:
-            pred1 = self.superpoint({'image': data['image1']})
+            superpoint_args1 = {'image': data['image1']}
+            if 'points1' in data:
+                superpoint_args1['points'] = data['points1']
+            pred1 = self.superpoint(superpoint_args1)
             pred = {**pred, **{k+'1': v for k, v in pred1.items()}}
 
         # Batch all features

--- a/models/superpoint.py
+++ b/models/superpoint.py
@@ -144,12 +144,13 @@ class SuperPoint(nn.Module):
 
     def forward(self, data):
         """ Compute keypoints, scores, descriptors for image """
+        # Pad
         x = data['image']
         original_shape = x.shape
-
         w_pad = original_shape[2] % 8
         h_pad = original_shape[3] % 8
         x = nn.functional.pad(x, (0, 0, w_pad, h_pad))
+
         # Shared Encoder
         x = self.relu(self.conv1a(x))
         x = self.relu(self.conv1b(x))
@@ -183,8 +184,6 @@ class SuperPoint(nn.Module):
         scores = [s[tuple(k.t())] for s, k in zip(scores, keypoints)]
 
         # Discard keypoints near the image borders
-        # print(keypoints)
-        # print(scores)
         keypoints, scores = list(zip(*[
             remove_borders(k, s, self.config['remove_borders'], h*8, w*8)
             for k, s in zip(keypoints, scores)]))


### PR DESCRIPTION
This pull request fixes one bug and adds two minor extensions of the current functionality:

1. **Fix output file names collision.** If you currently run `match_pairs.py` on [`scannet_test_pairs_with_gt.txt`](scannet_test_pairs_with_gt.txt) you get only 1248 output files instead of 1500 because of the same names for frames in different scenes. This pull request adds function `pair_names_to_id` which constructs a unique id for each pair based on the complete paths of an image pair and can be easily parsed.
2. **Add padding to allow any image resolution.** If you currently, for example, run `match_pairs.py` with `--resize 648, 484` you get an output of 648x480 since 484 is not divisible by 8. This pull request adds zero padding to preserve the original resolution.
3. **Add support for custom keypoints.** This is implemented via an additional argument for `match_pairs.py`. The argument `--input_points` is a path to a directory with the tensors containing custom keypoints. Naming convention of keypoint files is the same as for output matching files. The example of a SuperGlue matching of line segment endpoints:
![image](https://user-images.githubusercontent.com/67932762/198896880-6511cbd4-8a44-49c6-9dba-70184b87c24e.png)
![image](https://user-images.githubusercontent.com/67932762/198896892-60a32e8f-934f-43ff-8455-34fd6ff0091e.png)

